### PR TITLE
Fix repeated auth listener creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ const AuthSensitiveRoutesManager = () => {
     return () => {
       authListener?.subscription.unsubscribe();
     };
-  }, [loading]); // Added loading to dependency array to handle edge cases if needed
+  }, []); // Run once on mount to set up session listener
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- ensure session listener only mounted once

## Testing
- `bun install` *(fails: ConnectionRefused downloading package manifest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
